### PR TITLE
Add AgentWatch to Observability and Cost Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ A curated list of tools and resources for Platform Engineering.
 - [SigNoz- an open-source alternative to DataDog, NewRelic, etc.](https://github.com/signoz/signoz)
 - [Loki - low cost open source logging; self-hosted or SaaS](https://grafana.com/oss/loki/)
 - [Middleware - A Full-Stack Cloud Observability Platform](https://middleware.io)
+- [AgentWatch - Multi-agent observability with cascade failure detection and fleet heartbeats](https://github.com/nicofains1/agentwatch)
 
 ## Tooling— Authentication and Authorization
 - [CAS- Central Authentication Service](https://github.com/apereo/cas)


### PR DESCRIPTION
AgentWatch is an open-source multi-agent observability library for platform teams running AI agent fleets. It detects cascade failures across agents, tracks fleet-wide heartbeats, and provides forensic replay for incident investigation.

- **npm**: `@nicofains1/agentwatch`
- **GitHub**: https://github.com/nicofains1/agentwatch
- **Fits**: Observability section - monitoring for multi-agent AI systems in production