### PR TITLE
Add KubeStellar Console to Kubernetes tooling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ A curated list of tools and resources for Platform Engineering.
 - [Radius - Cloud-native application platform](https://radapp.io/)
 - [Meshery - A open source cloud native manager that enables the design and management of all Kubernetes-based infrastructure and applications (multi-cloud)](https://meshery.io)
 - [vCluster - A open source project that helps you create virtual clusters](https://vcluster.sh/)
+- [KubeStellar Console - Multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability](https://github.com/kubestellar/console)
 
 ## Tooling— Service mesh, API Gateway and App Proxies
 - [Istio- open source service mesh](https://istio.io/)


### PR DESCRIPTION
## Add KubeStellar Console

[KubeStellar Console](https://github.com/kubestellar/console) is a multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability, designed for platform engineering teams managing fleets of Kubernetes clusters.

### Key Features for Platform Engineers
- Multi-cluster dashboard with unified observability across edge-to-cloud deployments
- AI-powered operations (Claude, OpenAI, Gemini integration)
- 20+ CNCF project integrations (ArgoCD, Kyverno, Istio, Prometheus, etc.)
- Real-time cluster health monitoring and alerting
- Part of the [KubeStellar](https://kubestellar.io) CNCF Sandbox project

### Placement
Added to the **Tooling— Kubernetes, PAAS and Cloud services** section alongside related tools like Crossplane, KubeVela, Portainer, and vCluster.

Live demo: https://console.kubestellar.io