### PR TITLE
Update terraformer to maintained fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A curated list of tools and resources for Platform Engineering.
 - [okteto- spin up dev and preview environments](https://www.okteto.com/)
 
 ## Tooling— Infrastructure and Artifacts Management
-- [Terraformer- generate terraform files from existing infrastructure](https://github.com/GoogleCloudPlatform/terraformer)
+- [Terraformer- generate terraform files from existing infrastructure](https://github.com/chenrui333/terraformer)
 - [Terragrunt for deployment environments (dev/staging/prod) and other features](https://github.com/gruntwork-io/terragrunt)
 - [Atlantis - Terraform Pull Request Automation](https://www.runatlantis.io/)
 - [Jenkins Pipelines as Code](https://www.jenkins.io/doc/book/pipeline-as-code/)


### PR DESCRIPTION
The upstream `GoogleCloudPlatform/terraformer` was archived in March 2026. Update URL to the maintained fork.

Ref: chenrui333/terraformer#182