### PR TITLE
Add Ownkube to Kubernetes, PAAS and Cloud services

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ A curated list of tools and resources for Platform Engineering.
 - [Meshery - A open source cloud native manager that enables the design and management of all Kubernetes-based infrastructure and applications (multi-cloud)](https://meshery.io)
 - [vCluster - A open source project that helps you create virtual clusters](https://vcluster.sh/)
 - [KubeStellar Console - Multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability](https://github.com/kubestellar/console)
+- [Ownkube - AI-enabled developer platform that runs in your own AWS account, free on single-node k3s and usage-based on EKS](https://ownkube.io)
 
 ## Tooling— Service mesh, API Gateway and App Proxies
 - [Istio- open source service mesh](https://istio.io/)


### PR DESCRIPTION
Adds [Ownkube](https://ownkube.io) under **Tooling— Kubernetes, PAAS and Cloud services**.

Ownkube is an AI-enabled developer platform that runs in the customer's own AWS account (GCP coming soon). It gives teams a Heroku-style developer experience (git push, preview environments, managed databases, AI error detection) on top of vanilla cloud infrastructure they own. Free for teams on single-node k3s clusters; usage-based on EKS multi-node ($10/vCPU + $5/GB RAM per month). Compatible with AWS Activate credits, no markup on compute, zero lock-in.

Why it fits this section:
- PaaS-style platform layer (alternative framing to Dokku, Argonaut, Radius, Crossplane already in this section)
- Kubernetes-native (k3s and EKS data planes)
- Internal developer platform without requiring a platform team

Checklist:
- [x] One link added in the most relevant section
- [x] Alphabetical-ish placement preserved (appended at end of existing list, matching the style of recent additions)
- [x] No duplicates