### PR TITLE
Add mirrord to Kubernetes, PAAS and Cloud services

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ A curated list of tools and resources for Platform Engineering.
 - [Meshery - A open source cloud native manager that enables the design and management of all Kubernetes-based infrastructure and applications (multi-cloud)](https://meshery.io)
 - [vCluster - A open source project that helps you create virtual clusters](https://vcluster.sh/)
 - [KubeStellar Console - Multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability](https://github.com/kubestellar/console)
+- [mirrord](https://metalbear.com/mirrord/) - Open source tool that runs local code as if it were a pod in a remote Kubernetes cluster.
 
 ## Tooling— Service mesh, API Gateway and App Proxies
 - [Istio- open source service mesh](https://istio.io/)


### PR DESCRIPTION
Adds mirrord to the Kubernetes, PAAS and Cloud services section.

mirrord is an open source developer tool that lets engineers run local code as if it were a pod inside their remote Kubernetes cluster, with real env vars, DNS, network, and inbound traffic. Fits alongside vCluster (virtual K8s clusters) and KubeVela (cloud-native app platform) as Kubernetes-development infrastructure.

- Repo: https://github.com/metalbear-co/mirrord (5,059 stars, 57 contributors, MIT)
- Site: https://metalbear.com/mirrord/
- Docs: https://metalbear.com/mirrord/docs

Entry uses the standard `[Name](URL) - Description.` format per CONTRIBUTING.md and awesome-lint, even though some neighboring entries use an older in-link description style.