### PR TITLE
Add AgentTier to Internal Developer Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ A curated list of tools and resources for Platform Engineering.
 - [Roadie - SaaS-based Internal Developer Portal](https://roadie.io)
 
 ## Tooling— Internal Developer Platforms
+- [AgentTier - Kubernetes-native platform that provisions isolated, persistent sandboxes for human developers and AI agents through a Sandbox CRD, with built-in governance and a streaming agent-mode REST API](https://github.com/agenttier/agenttier)
 - [OpenChoreo - A complete, modular, open-source developer platform](https://openchoreo.dev/)
 
 ## Tooling— Microservices


### PR DESCRIPTION
This PR adds [AgentTier](https://github.com/agenttier/agenttier) under `## Tooling— Internal Developer Platforms`.

AgentTier is a Kubernetes-native platform that provisions isolated, persistent sandboxes for both human developers and AI agents from a single `Sandbox` CRD. Each sandbox is a Pod + PVC + default-deny NetworkPolicy with optional gVisor isolation, hierarchical (cluster → namespace) governance policies, an authenticated browser terminal, and a streaming agent-mode REST API (`POST /configure` + SSE-streaming `POST /invoke`). Distributed as a single Helm chart, with a Python SDK, a Go CLI, and a React Web UI.

License: Apache-2.0. Project URL: https://github.com/agenttier/agenttier.

**Compliance with CONTRIBUTING.md:**

- ✅ Format follows the documented `- [Descriptive Name - short description](URL)` style and matches the existing OpenChoreo entry above.
- ✅ Alphabetical placement: `AgentTier` sorts before `OpenChoreo` so the entry is the new first row.
- ✅ `npm test` (`awesome-lint`) reports the same single pre-existing baseline error (`Git repository must be at least 30 days old`) before and after my change. No new lint errors introduced.
- ✅ Single-line diff. ToC unchanged because no new heading was added.
