### PR TITLE
Add piqc — GPU waste scanner for Kubernetes inference clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A curated list of tools and resources for Platform Engineering.
 - [AgentWatch - Multi-agent observability with cascade failure detection and fleet heartbeats](https://github.com/nicofains1/agentwatch)
 - [KubeStellar Console — AI-powered multi-cluster Kubernetes dashboard with real-time observability, CNCF integrations, and AI-guided operations. CNCF Sandbox project.](https://console.kubestellar.io)
 - [Ingero - eBPF-based GPU causal observability agent. Helm chart deploys as DaemonSet on K8s; traces CUDA APIs and host kernel events to explain GPU latency in AI/ML clusters](https://github.com/ingero-io/ingero)
+- [piqc - Open-source GPU waste scanner for Kubernetes inference clusters. Detects tier misplacement, idle capacity, OOM risk, and CPU:GPU imbalance — model-aware, read-only, no write permissions required](https://github.com/paralleliq/piqc)
 
 ## Tooling— Authentication and Authorization
 - [CAS- Central Authentication Service](https://github.com/apereo/cas)


### PR DESCRIPTION
**[piqc](https://github.com/paralleliq/piqc)** is an open-source, read-only GPU waste scanner for Kubernetes inference clusters — a natural complement to Ingero already in this section.

Where Ingero traces CUDA APIs to explain GPU latency, piqc scans running vLLM workloads to detect four waste patterns that account for 20-40% of GPU spend in production inference:

- **Tier misplacement** - model on a GPU with more memory/compute than it needs
- **Dark capacity** - GPU allocated but serving no live traffic
- **OOM risk** - model approaching GPU memory ceiling
- **CPU:GPU imbalance** - CPU saturation throttling GPU throughput

Deploys as a Kubernetes Job, no write permissions required, exits after reporting. Apache 2.0.

Placed in Observability and Cost Optimization alongside Ingero and OpenCost.
