### PR TITLE
Add Fortem — ECS Fargate fleet control plane to IDP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A curated list of tools and resources for Platform Engineering.
 
 ## Tooling— Internal Developer Platforms
 - [OpenChoreo - A complete, modular, open-source developer platform](https://openchoreo.dev/)
+- [Fortem - ECS Fargate fleet control plane for platform engineers](https://fortem.dev). Per-environment scheduling, fleet-wide visibility, developer self-service, AI diagnostics. Works with existing Terraform.
 
 ## Tooling— Microservices
 - [JHipster for microservices creation and integration at scale](https://www.jhipster.tech/)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A curated list of tools and resources for Platform Engineering.
 
 ## Tooling— Internal Developer Platforms
 - [OpenChoreo - A complete, modular, open-source developer platform](https://openchoreo.dev/)
-- [Fortem - ECS Fargate fleet control plane for platform engineers](https://fortem.dev). Per-environment scheduling, fleet-wide visibility, developer self-service, AI diagnostics. Works with existing Terraform.
+- [Fortem](https://fortem.dev) - ECS Fargate fleet control plane for platform engineers. Per-environment scheduling, fleet-wide visibility, developer self-service, AI diagnostics. Works with existing Terraform.
 
 ## Tooling— Microservices
 - [JHipster for microservices creation and integration at scale](https://www.jhipster.tech/)


### PR DESCRIPTION
Add [Fortem](https://fortem.dev) to Internal Developer Platforms.

Fortem is a control plane for teams running 10+ ECS Fargate environments. It provides per-environment scheduling (60-70% cost reduction on dev/staging), fleet-wide visibility, developer self-service with RBAC, environment templates, and AI diagnostics. Works with existing Terraform — no rewrite required.

- Website: https://fortem.dev
- Demo: https://demo.fortem.dev
- Free Fleet Audit: https://fortem.dev/audit