### PR TITLE
Add Radar to Kubernetes tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ A curated list of tools and resources for Platform Engineering.
 - [Meshery - A open source cloud native manager that enables the design and management of all Kubernetes-based infrastructure and applications (multi-cloud)](https://meshery.io)
 - [vCluster - A open source project that helps you create virtual clusters](https://vcluster.sh/)
 - [KubeStellar Console - Multi-cluster Kubernetes dashboard with AI-powered operations and real-time observability](https://github.com/kubestellar/console)
+- [Radar](https://github.com/skyhook-io/radar) - Open-source Kubernetes visibility tool for topology, events, resources, Helm, GitOps, traffic, cost, audit, access control, and MCP for AI tools.
 - [mirrord](https://metalbear.com/mirrord/) - Open source tool that runs local code as if it were a pod in a remote Kubernetes cluster.
 
 ## Tooling— Service mesh, API Gateway and App Proxies


### PR DESCRIPTION
Adds Radar to the Kubernetes, PAAS and Cloud services section.\n\nRadar is an open-source Kubernetes visibility tool for topology, events, resources, Helm, GitOps, traffic, cost, audit, access control, and MCP for AI tools.\n\nValidation:\n- npm test