### PR TITLE
Add Ota to internal developer platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ A curated list of tools and resources for Platform Engineering.
 
 ## Tooling— Internal Developer Platforms
 - [OpenChoreo - A complete, modular, open-source developer platform](https://openchoreo.dev/)
+- [Ota](https://github.com/ota-run/ota) - Open-source repo execution governance with machine-readable contracts for setup, verification, workflows, runtime proof, and agent-safe execution.
 
 ## Tooling— Microservices
 - [JHipster for microservices creation and integration at scale](https://www.jhipster.tech/)


### PR DESCRIPTION
Adds Ota under **Tooling— Internal Developer Platforms**.\n\nOta is an open-source repo execution governance tool with machine-readable contracts for setup, verification, workflows, runtime proof, and agent-safe execution.\n\nProject: https://github.com/ota-run/ota