### PR TITLE
Add Tombstone — self-hosted feature flag platform with circuit-breaker auto-rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ A curated list of tools and resources for Platform Engineering.
 - [ConfigCat - Privacy-first feature flag service](https://configcat.com/)
 - [OpenFeature - community-developed specification to standardise feature flag management](https://github.com/open-feature#welcome-to-the-openfeature-project-)
 - [Launchdarkly- feature flags paid service](https://launchdarkly.com/)
+- [Tombstone](https://github.com/sairam0424/Tombstone) - Self-hosted feature flag platform with circuit-breaker auto-rollback, blast-radius gating, and causal incident correlation. MIT, Go/Python/TypeScript.
 - [Git Guide: Generate A Changelog From Your Git Commit Messages](https://mokkapps.de/blog/how-to-automatically-generate-a-helpful-changelog-from-your-git-commit-messages/)
 - [Update NPM, pip, Gem etc. dependencies](https://github.com/renovatebot/renovate)
 - [Upgrade microservices](https://www.jhipster.tech/upgrading-an-application/#-upgrading-an-application)


### PR DESCRIPTION
## What

Adds [Tombstone](https://github.com/sairam0424/Tombstone) to the **Feature flags, environments and change management** section.

## Why it belongs here

Tombstone is a self-hosted production intelligence layer for feature flags — directly relevant to platform engineers managing flag inventory at scale:

- **Circuit-breaker auto-rollback**: when a flag causes >5% errors over 100 requests in a 10s window, it disables automatically — no manual kill switch required
- **Blast-radius scoring**: BLOCKED/HIGH/MEDIUM/LOW gate before every flag change based on traffic %, dependent flags, and historical incident correlation
- **Causal incident correlation**: `GET /api/v1/incidents/{id}/correlation` returns flags ranked by change recency/blast radius — answers "was it a flag?" in one call
- **Kubernetes operator** with FeatureFlag + FlagPolicy CRDs, GitOps sync, OPA RBAC
- **OpenFeature-compatible** (TypeScript provider ships with the SDK)

MIT licensed, actively maintained (v1.2.1 released 2026-07-05), self-hosted via `make dev`.

## Entry added

Under **Tooling— Feature flags, environments and change management**, after LaunchDarkly:

```markdown
- [Tombstone](https://github.com/sairam0424/Tombstone) - Self-hosted feature flag platform with circuit-breaker auto-rollback, blast-radius gating, and causal incident correlation. MIT, Go/Python/TypeScript.
```