### PR TITLE
Add nika to Internal Developer Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of tools and resources for Platform Engineering.
 ## Tooling— Internal Developer Platforms
 - [OpenChoreo - A complete, modular, open-source developer platform](https://openchoreo.dev/)
 - [Ota](https://github.com/ota-run/ota) - Open-source repo execution governance with machine-readable contracts for setup, verification, workflows, runtime proof, and agent-safe execution.
+- [nika](https://github.com/supernovae-st/nika) - Open-source workflow engine for AI (Rust, AGPL): platform teams codify agent tasks as .nika.yaml contracts, statically checked before execution (schema, permits, cost caps), with tamper-evident traces for audit.
 
 ## Tooling— Microservices
 - [JHipster for microservices creation and integration at scale](https://www.jhipster.tech/)


### PR DESCRIPTION
One line under Internal Developer Platforms, next to Ota (same problem family: execution governance for agent work). nika is an open-source (AGPL, Rust) workflow engine for AI: platform teams capture agent tasks as .nika.yaml contracts that are statically checked before anything runs (schema validation, filesystem/exec/network permits, cost ceilings) and produce tamper-evident traces after, so AI automation gets the same golden-path treatment as the rest of the platform. Local-first: works against Ollama/llama.cpp/vLLM or cloud providers, and fully offline with the built-in mock provider. Disclosure: I am the nika author (first-party submission).