### PR TITLE
Add Darkmoon (autonomous AI pentest platform)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A curated list of tools and resources for Platform Engineering.
 - [KICS by Checkmarx- detect security vulnerabilities, compliance issues, and infrastructure misconfigurations](https://github.com/Checkmarx/kics)
 - [Semgrep security simple static analysis](https://semgrep.dev/)
 - [Checkov Policy-as-code](https://www.checkov.io/)
+- [Darkmoon](https://github.com/ASCIT31/Dark-Moon) - Open source (GPL-3.0) autonomous AI penetration testing platform covering web, API, Active Directory and Kubernetes.
 - [kube-bench checks whether Kubernetes security is aording to CIS K8S Benchmark](https://github.com/aquasecurity/kube-bench)
 - [Terraform Guardrails with OPA](https://compellingcloud.substack.com/p/navigating-safety-a-beginners-guide)
 - [Secure the software supply chain for OPA policies](https://github.com/opcr-io/policy)


### PR DESCRIPTION
Thank you for maintaining this list. We would like to propose adding Darkmoon to the Tooling Security and Policies section. Darkmoon is an open source (GPL 3.0) autonomous AI penetration testing platform that covers web, API, Active Directory and Kubernetes, and it runs fully self hosted. It sits naturally alongside the other security and auditing tools already listed here. Repository: https://github.com/ASCIT31/Dark-Moon