### PR TITLE
Add API Status Check to Observability and Cost Optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ A curated list of tools and resources for Platform Engineering.
 - [KubeStellar Console — AI-powered multi-cluster Kubernetes dashboard with real-time observability, CNCF integrations, and AI-guided operations. CNCF Sandbox project.](https://console.kubestellar.io)
 - [Ingero - eBPF-based GPU causal observability agent. Helm chart deploys as DaemonSet on K8s; traces CUDA APIs and host kernel events to explain GPU latency in AI/ML clusters](https://github.com/ingero-io/ingero)
 - [ZopNight - Multi-cloud FinOps autopilot for AWS, GCP, Azure. Auto-discovers 200+ resource types, auto-scales and schedules them on cron timetables, and surfaces 400+ audit rules pinpointing waste with one-click remediation. Supports Kubernetes (EKS/GKE/AKS) namespace-level scheduling.](https://zopnight.com/)
+- [API Status Check - third-party dependency status for 285 developer APIs; reads the vendors' own status pages and live-probes their endpoints, so an on-call can tell a vendor outage from their own regression without instrumenting anything. Free web checks plus an MCP server for agents.](https://apistatuscheck.com/)
 
 ## Tooling— Authentication and Authorization
 - [CAS- Central Authentication Service](https://github.com/apereo/cas)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ape",
+  "name": "awesome-platform-engineering",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "awesome-platform-engineering",
+  "name": "ape",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
One line, added at the end of **Tooling— Observability and Cost Optimization**.

### The gap

Every tool in that section — Netdata, Jaeger, Sentry, SigNoz, SkyWalking, Loki, Middleware, AgentWatch, Ingero — instruments **your** platform and tells you when **your** services misbehave. None of them can answer the first question an on-call actually asks at 3am when the checkout flow starts throwing 500s: *is this us, or is it Stripe?*

That question is a platform-engineering problem specifically because the answer lives outside the boundary your telemetry covers. API Status Check reads what 285 vendors publish on their own status pages, and live-probes their endpoints at call time, so the "is it them?" half of an incident is answerable without adding a single agent, exporter or sidecar to your cluster.

It complements rather than competes with anything already listed: SigNoz sees your spans go red, this tells you the upstream that made them red.

### Disclosure

- **Self-submission.** I built it.
- **Placement**: appended to the end of the section rather than sorted in — `CONTRIBUTING.md` doesn't specify an order and the section isn't alphabetical, but say the word and I'll move it.
- **Cadence, stated plainly**: the on-demand check (web UI, and the `get_api_status` MCP tool) probes live at request time. The *background* monitor that fills the cached dashboard runs hourly, not continuously. If a section entry implies sub-minute detection to you, that's not what this is, and I'd rather you know before merging than after.
- **Free tier is the whole checking surface**; there's a paid alert product on top of it.
- Verified before filing: `get_api_status` on stripe / openai / anthropic all returned `up` with live response times of 42ms / 64ms / 26ms just now.

`npm test` (awesome-lint) passes on the branch.
