### PR TITLE
Add BunkerWeb to app proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ A curated list of tools and resources for Platform Engineering.
 - [mirrord](https://metalbear.com/mirrord/) - Open source tool that runs local code as if it were a pod in a remote Kubernetes cluster.
 
 ## Tooling— Service mesh, API Gateway and App Proxies
+- [BunkerWeb](https://github.com/bunkerity/bunkerweb) - Open-source Web Application Firewall and reverse proxy.
 - [Istio- open source service mesh](https://istio.io/)
 - [Kong- API Gateway and Service Connectivity Platform](https://konghq.com/)
 - [Traefik- Cloud Native Application Proxy](https://traefik.io/)


### PR DESCRIPTION
Adds BunkerWeb under Service mesh, API Gateway and App Proxies as an open-source Web Application Firewall and reverse proxy.

Checks:

- `npm test`
- `git diff --check`
