### PR TITLE
Add SandBase Harness to platform engineering tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A curated list of tools and resources for Platform Engineering.
 ## Tooling— Internal Developer Platforms
 - [OpenChoreo - A complete, modular, open-source developer platform](https://openchoreo.dev/)
 - [Ota](https://github.com/ota-run/ota) - Open-source repo execution governance with machine-readable contracts for setup, verification, workflows, runtime proof, and agent-safe execution.
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) - Local-first agent runtime and MCP bridge for auditable sessions, sandboxed execution, approvals, and Docker/Kubernetes-backed platform workflows.
 
 ## Tooling— Microservices
 - [JHipster for microservices creation and integration at scale](https://www.jhipster.tech/)


### PR DESCRIPTION
## Summary

- add SandBase Harness to the Internal Developer Platforms section
- link to the official repository
- describe its local-first agent runtime, MCP bridge, auditable sessions, approvals, and Docker/Kubernetes-backed workflows

SandBase Harness is an open-source runtime and MCP bridge for platform and DevOps workflows. The entry follows the list's existing concise format and uses capabilities documented in the project.

Maintainer disclosure: I maintain SandBase Harness and opened this focused entry for review.

Verification:
- Repository: https://github.com/sandbaseai/sandbase-harness
- Latest release: https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8
- Installation guide: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/mcp-install.md
