### PR TITLE
Add YYLO to Internal Developer Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A curated list of tools and resources for Platform Engineering.
 - [OpenChoreo - A complete, modular, open-source developer platform](https://openchoreo.dev/)
 - [Ota](https://github.com/ota-run/ota) - Open-source repo execution governance with machine-readable contracts for setup, verification, workflows, runtime proof, and agent-safe execution.
 - [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) - Local-first agent runtime and MCP bridge for auditable sessions, sandboxed execution, approvals, and Docker/Kubernetes-backed platform workflows.
+- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents and repeatable workflows with typed task, validation, merge, and release-readiness boundaries; each task runs in a dedicated branch/worktree and a merge queue owns risk-based review for receipt-backed repository changes.
 
 ## Tooling— Microservices
 - [JHipster for microservices creation and integration at scale](https://www.jhipster.tech/)


### PR DESCRIPTION
## What this adds

One entry for **YYLO** appended at the bottom of `## Tooling— Internal Developer Platforms`:

- [YYLO](https://github.com/yylo-dev/yylo) - Command-line orchestrator for coding agents and repeatable workflows with typed task, validation, merge, and release-readiness boundaries; each task runs in a dedicated branch/worktree and a merge queue owns risk-based review for receipt-backed repository changes.

## Why it fits

The Internal Developer Platforms section already houses the coding-agent platform band this entry extends:

- [Ota](https://github.com/ota-run/ota) (#52) — "repo execution governance with machine-readable contracts … agent-safe execution"
- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) (#63) — "local-first agent runtime … auditable sessions, sandboxed execution, approvals"

YYLO is the repository-change layer of the same stack: it orchestrates coding agents behind typed task, validation, merge, and release-readiness boundaries, runs each task in a dedicated branch/worktree, and its merge queue owns risk-based review with receipt-backed changes.

## Quality signals

- MIT licensed (GitHub license API live)
- ~8 months old, daily pushes (latest 2026-09-03)
- npm: [@yylo/cli](https://www.npmjs.com/package/@yylo/cli) — 563 downloads last month
- Orchestrates Pi and Codex subagent namespaces

## Verification

- `npm install && npm test` (awesome-lint): **passes** on this branch, run locally per CONTRIBUTING
- +1 line, README.md only, appended at section bottom matching the shape of #52 and #63

## Disclosure

I'm on the team that builds YYLO; this submission was prepared with an AI coding agent against the live README, following the contributing example format. Happy to re-file under a different Tooling section if you prefer.
