### PR TITLE
Fix the Zopnight entry: correct name, live URL and description

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ A curated list of tools and resources for Platform Engineering.
 - [AgentWatch - Multi-agent observability with cascade failure detection and fleet heartbeats](https://github.com/nicofains1/agentwatch)
 - [KubeStellar Console — AI-powered multi-cluster Kubernetes dashboard with real-time observability, CNCF integrations, and AI-guided operations. CNCF Sandbox project.](https://console.kubestellar.io)
 - [Ingero - eBPF-based GPU causal observability agent. Helm chart deploys as DaemonSet on K8s; traces CUDA APIs and host kernel events to explain GPU latency in AI/ML clusters](https://github.com/ingero-io/ingero)
-- [ZopNight - Multi-cloud FinOps autopilot for AWS, GCP, Azure. Auto-discovers 200+ resource types, auto-scales and schedules them on cron timetables, and surfaces 400+ audit rules pinpointing waste with one-click remediation. Supports Kubernetes (EKS/GKE/AKS) namespace-level scheduling.](https://zopnight.com/)
+- [Zopnight - Multi-cloud cost management and FinOps for AWS, Azure, GCP, Databricks and Snowflake. Auto-discovers 200+ resource types, auto-scales and schedules them on cron timetables, and surfaces 400+ audit rules pinpointing waste with one-click remediation. Supports Kubernetes (EKS/GKE/AKS) namespace-level scheduling, plus a hosted MCP server so AI assistants can query the same cost and inventory data.](https://zop.dev/zopnight)
 
 ## Tooling— Authentication and Authorization
 - [CAS- Central Authentication Service](https://github.com/apereo/cas)


### PR DESCRIPTION
Small correction to the Zopnight entry under **Tooling — Observability and Cost Optimization**, added in #51.

Three fixes:

- **Name** — it is spelled **Zopnight**, with a lowercase `n`, not "ZopNight".
- **Link** — `zopnight.com` is no longer the product page; it is now https://zop.dev/zopnight.
- **Description** — "FinOps autopilot" replaced with what it actually does, and the cloud list corrected: Databricks and Snowflake are covered alongside AWS, Azure and GCP. Also mentions the hosted MCP server, which did not exist when the entry was written.

No change to the entry's position or format. Every factual claim already in the entry (200+ resource types, 400+ audit rules, Kubernetes namespace-level scheduling) is unchanged.
