### PR TITLE
Add Featureflip to feature flags tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A curated list of tools and resources for Platform Engineering.
 - [ConfigCat - Privacy-first feature flag service](https://configcat.com/)
 - [OpenFeature - community-developed specification to standardise feature flag management](https://github.com/open-feature#welcome-to-the-openfeature-project-)
 - [Launchdarkly- feature flags paid service](https://launchdarkly.com/)
+- [Featureflip - flat-priced feature flag service that removes its own dead flags by pull request](https://featureflip.io/)
 - [Git Guide: Generate A Changelog From Your Git Commit Messages](https://mokkapps.de/blog/how-to-automatically-generate-a-helpful-changelog-from-your-git-commit-messages/)
 - [Update NPM, pip, Gem etc. dependencies](https://github.com/renovatebot/renovate)
 - [Upgrade microservices](https://www.jhipster.tech/upgrading-an-application/#-upgrading-an-application)


### PR DESCRIPTION
Adds [Featureflip](https://featureflip.io) to **Tooling— Feature flags, environments and change management**, after the Launchdarkly line.

**Disclosure:** I work on Featureflip — self-submission.

Relevant to a platform-engineering audience specifically because of the change-management half of that section heading: dead flags are detected from evaluation traffic, and a GitHub Action opens one reviewable pull request per flag that deletes the code path across thirteen languages. The rewrite works on the syntax tree with no LLM, so the same input always produces the same diff, and it refuses anything it cannot do safely. That closes the loop the other entries in this section leave open — every flag platform helps you add flags, and the cleanup is what teams carry forever.

Also relevant here: flat pricing with no per-seat or per-evaluation charge, a Management API and Terraform provider on every plan, and OpenFeature providers for Node.js, .NET, Python, Go and Java (the OpenFeature spec is already listed two lines above).

I matched the section's `[Name - description](url)` link-text convention. Happy to reword or move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DFrAfK9aLuTuYw9Qo6XwsU