### PR TITLE
Add OrcaReplay to Tooling— Testing and Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ A curated list of tools and resources for Platform Engineering.
 - [Awesome Test Automation- a list of test automation frameworks, tools etc.](https://github.com/atinfo/awesome-test-automation)
 - [Swarmia- tools to gather and improve engineering and DORA metrics](https://www.swarmia.com/product/objections/)
 - [Hydra Lab: build your intelligent cloud testing system](https://github.com/microsoft/HydraLab)
+- [OrcaReplay- record an agent or service run at its LLM-provider boundary and replay it offline, with no provider call and no API key](https://github.com/Continuum-AI-Corp/OrcaReplay)
 
 ## Tooling— Observability and Cost Optimization
 - [Netdata- Open-source infrastructure monitoring](https://www.netdata.cloud/)


### PR DESCRIPTION
Adds OrcaReplay to **Tooling— Testing and Metrics**.

The gap it fills for a platform team: anything with an LLM in the path is the one component you cannot cheaply put in a test. Hitting a provider in CI costs money, needs a key, and does not answer the same way twice — so those paths usually go untested.

This records the run at the HTTP boundary to the provider, from **outside the process**, and serves the recording back:

```console
$ orca record generic-openai -- python my_service.py
info recorded run=run_8f21c3 events=41 exit=0

$ orca replay last
info replaying exchanges=6 egress=blocked
info replay.done reused=6/6 exact=6 divergences=0 exit=0
```

`exact=6` means every replayed request matched the recording byte for byte, and the origin process was killed before the replay, so nothing could have quietly reached the network. Your own code runs for real — only the provider's answers come from the trace. Nothing is imported into the service, so it does not care what language or framework it is.

For the platform angle specifically: the same recording is a regression test that costs nothing to run, and a failed run becomes an artifact a colleague can reproduce **without your credentials**.

Two limits, stated so the entry is not read as more than it is:

- `egress=blocked` means **provider egress, not network isolation** — the replayed process still makes its own outbound calls for real. It is not a sandbox.
- A matching replay shows the *recorded* run reproduces; it is not a determinism result, because the model is not re-asked.

Format follows the section's `[Name- description](url)` convention. Apache-2.0, Node 20+. Disclosure: I maintain it.
